### PR TITLE
Conditional unescape on Base64 decode

### DIFF
--- a/js/redirect.js
+++ b/js/redirect.js
@@ -246,6 +246,9 @@ Redirect.prototype = {
 				repl = encodeURIComponent(repl);
 			}
 			if (this.processMatches == 'base64decode') {
+				if (repl.indexOf('%') > -1) {
+					repl = unescape(repl);
+				}
 				repl = atob(repl);
 			}
 			resultUrl = resultUrl.replace(new RegExp('\\$' + i, 'gi'), repl);


### PR DESCRIPTION
This patch will fix Base64 decoding if match has % encoded character.
This won't break current decoding system because Base64 can't have % character anyway.

**Example case:**

```
http://mp3indirdim.com/engine/go.php?url=aHR0cDovL2JpbmcuY29tLw%3D%3D
```

1. This URL will redirect user to `http://bing.com/`
2. If I add a redirection to `http://google.com/` with the settings I provide below, it will **not work** in the current version  
3. Because Redirector will try to decode `aHR0cDovL2JpbmcuY29tLw%3D%3D` instead of `aHR0cDovL2JpbmcuY29tLw==` thus will fail / throw error

**Settings:**

* Pattern: `http://mp3indirdim.com/engine/go.php?url=*`
* Decoding: Base64